### PR TITLE
강의계획서 보기 페이지 연결

### DIFF
--- a/frontend/src/editor/parser/blocks/ParsedDataTableBlock.tsx
+++ b/frontend/src/editor/parser/blocks/ParsedDataTableBlock.tsx
@@ -17,7 +17,6 @@ function ParsedDataTableBlock(props: Props) {
   }
   useEffect(() => {
     getData().then((res) => {
-      console.log(res);
       setData(res.enrollments);
     });
   }, []);

--- a/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx
+++ b/frontend/src/editor/parser/blocks/ParsedTableBlock.tsx
@@ -61,12 +61,12 @@ const ParsedTableBlock = (props: Props) => {
         ) : (
           <div>
             <div className={style.cell} style={{ textAlign: data.align }}>
-              {data.data?.text}
+              {props.defaultValues?.["info"]?.[data?.name]}
             </div>
           </div>
         );
       case "select":
-        return (
+        return props.auth === "edit" ? (
           <div
             className={`${style.cell} ${style.select}`}
             placeholder={data.placeholder ?? "입력"}
@@ -80,6 +80,32 @@ const ParsedTableBlock = (props: Props) => {
                   props.returnData[data?.name] = e.target.value;
                 }
               }}
+            >
+              {data.options.map((val: any) => {
+                return (
+                  <option key={val.id} value={val.value}>
+                    {val.text}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+        ) : (
+          <div
+            className={`${style.cell} ${style.select}`}
+            placeholder={data.placeholder ?? "입력"}
+          >
+            <select
+              style={{ textAlign: data.align, fontSize: data.fontSize }}
+              onChange={(e) => {
+                if (data?.name === undefined) {
+                  props.returnData[data?.id] = e.target.value;
+                } else {
+                  props.returnData[data?.name] = e.target.value;
+                }
+              }}
+              defaultValue={props.defaultValues?.["info"]?.[data?.name]}
+              disabled={true}
             >
               {data.options.map((val: any) => {
                 return (

--- a/frontend/src/pages/admin/schools/tab/seasons/tab/Form.tsx
+++ b/frontend/src/pages/admin/schools/tab/seasons/tab/Form.tsx
@@ -158,7 +158,7 @@ const Form = (props: Props) => {
                 key: "_id",
                 type: "button",
                 onClick: (e: any) => {
-                  const id = e.target.dataset.value;
+                  const id = e._id;
 
                   getForm(id).then((res) => {
                     switch (selectFormType) {

--- a/frontend/src/pages/courses/Enroll.tsx
+++ b/frontend/src/pages/courses/Enroll.tsx
@@ -86,8 +86,8 @@ const Enrollment = (props: Props) => {
         <div style={{ height: "24px" }}></div>
 
         <Table
-        filter
-        filterSearch
+          filter
+          filterSearch
           type="object-array"
           data={courses}
           header={[
@@ -144,7 +144,7 @@ const Enrollment = (props: Props) => {
               key: "courseName",
               type: "button",
               onClick: (e: any) => {
-                navigate(`courses/${e.target.dataset.value}`, {
+                navigate(`../courses/${e._id}`, {
                   replace: true,
                 });
               },

--- a/frontend/src/pages/courses/Pid.tsx
+++ b/frontend/src/pages/courses/Pid.tsx
@@ -31,13 +31,11 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import useDatabase from "hooks/useDatabase";
-
 import { useAuth } from "contexts/authContext";
 
 // components
 import Divider from "components/divider/Divider";
 import NavigationLinks from "components/navigationLinks/NavigationLinks";
-import Tab from "components/tab/Tab";
 
 import style from "style/pages/courses/course.module.scss";
 import EditorParser from "editor/EditorParser";
@@ -49,53 +47,12 @@ type Props = {};
 const Course = (props: Props) => {
   const { pid } = useParams<"pid">();
   const navigate = useNavigate();
-  const database = useDatabase();
-  const { currentSchool, currentUser, currentSeason } = useAuth();
+  const { currentSeason } = useAuth();
 
-  const [courseData, setCourseData] = useState({
-    _id: 123794078125781,
-    timestamps: "2022-06-18 10:00:00",
-    classTitle: "웹프로그래밍 기초",
-    userId: "mrgoodway",
-    userName: "조은길",
-    schoolId: "bmrhs",
-    schoolName: "별무리고등학교",
-    year: "2022학년도",
-    term: "1쿼터",
-    comfirm: "Y",
-    time: [
-      {
-        label: "화2",
-        start: "09:45",
-        end: "10:30",
-      },
-      {
-        label: "목2",
-        start: "09:45",
-        end: "10:30",
-      },
-    ],
-    point: "2",
-    classroom: "101호",
-    subject: ["정보", "웹프로그래밍1"],
-    teachers: [
-      {
-        userId: "mrgoodway",
-        userName: "조은길",
-      },
-      {
-        userId: "asdfqvd",
-        userName: "이세찬",
-      },
-    ],
-    description: {
-      description: "웹프로그래밍을 배운다.",
-      attachments: [
-        "https://www.youtube.com/watch?v=pEE_uJ-joUA",
-        "https://www.next-t.co.kr/public/uploads/7b7f7e2138e29e598cd0cdf2c85ea08d.jpg",
-      ],
-    },
-  });
+  const database = useDatabase();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const [courseData, setCourseData] = useState<any>();
 
   async function getCourseData() {
     const result = await database.R({
@@ -122,7 +79,7 @@ const Course = (props: Props) => {
       <div className={style.category}>
         멘토:{" "}
         {_.join(
-          courseData?.teachers.map((teacher) => {
+          courseData?.teachers.map((teacher: any) => {
             return teacher.userName;
           }),
           ", "
@@ -134,7 +91,7 @@ const Course = (props: Props) => {
       <div className={style.category}>
         시간:{" "}
         {_.join(
-          courseData?.time.map((timeBlock) => {
+          courseData?.time.map((timeBlock: any) => {
             return timeBlock.label;
           }),
           ", "
@@ -155,7 +112,7 @@ const Course = (props: Props) => {
     getCourseData()
       .then((result) => {
         setCourseData(result);
-        categories();
+        setIsLoading(false);
       })
       .catch((err) => {
         alert(err.response.data.message);
@@ -168,69 +125,13 @@ const Course = (props: Props) => {
     return (
       <EditorParser
         auth="view"
-        // onChange={(data) => {
-        //   setCourseMoreInfo(data);
-        // }}
         defaultValues={courseData}
         data={currentSeason?.formSyllabus}
       />
     );
-
-    return (
-      <div className={style.class_info}>
-        전반적인 수업 설명 등 사진? 영상? 등
-        <br />
-        <br />
-        이상을 청춘의 낙원을 그들은 이것이다. 이상이 눈이 앞이 실로 있으랴? 싹이
-        얼마나 바이며, 말이다. 모래뿐일 꾸며 속에서 길을 사막이다. 천지는 사랑의
-        이것은 황금시대를 운다. 보이는 싸인 끝에 철환하였는가? 발휘하기 할지니,
-        이상은 실로 방지하는 할지라도 용감하고 쓸쓸하랴? 얼음이 소리다.이것은
-        황금시대의 것은 듣기만 것이다. 열락의 유소년에게서 대한 구하기 커다란
-        능히 생명을 사막이다. 가슴에 기관과 살 그들은 것은 하였으며, 아니한
-        가지에 넣는 봄바람이다. 황금시대의 위하여서 별과 때까지 청춘을 품고 대한
-      </div>
-    );
-  };
-  const TeacherInfo = () => {
-    return (
-      <div className={`${style.tab_item} ${style.teachers_container}`}>
-        <div className={style.teachers}>
-          {courseData.teachers.map((value, index) => {
-            return (
-              <>
-                <div key={index} className={style.teacher}>
-                  <span className={style.name}>{value.userName} 선생님</span>
-                  <span className={style.subject}>
-                    과목: {courseData.subject[0]}
-                  </span>
-                </div>
-              </>
-            );
-          })}
-          {/* 선생님,prev classes, 관련 수업등 */}
-        </div>
-      </div>
-    );
-  };
-  const SyllabusInfo = () => {
-    return (
-      <div className={style.tab_item}>
-        1.
-        <br />
-        2.
-        <br />
-        3.
-      </div>
-    );
-  };
-  const ClassMatrialInfo = () => {
-    return <div className={style.tab_item}>교제? 준비물등 수업에 필요한것</div>;
-  };
-  const EvaluationInfo = () => {
-    return <div className={style.tab_item}>평가 계획</div>;
   };
 
-  return (
+  return !isLoading ? (
     <div className={style.section}>
       <NavigationLinks />
       <div className={style.title}>{courseData.classTitle}</div>
@@ -240,19 +141,9 @@ const Course = (props: Props) => {
       <Divider />
 
       <ClassInfo />
-      <div className={style.tab}>
-        <Tab
-          items={{
-            "강의 계획": <SyllabusInfo />,
-            선생님: <TeacherInfo />,
-            교재: <ClassMatrialInfo />,
-            평가: <EvaluationInfo />,
-          }}
-        />
-      </div>
-      <Divider />
-      <div>비슷한 수업</div>
     </div>
+  ) : (
+    <div>로딩중</div>
   );
 };
 

--- a/frontend/src/pages/courses/Pid.tsx
+++ b/frontend/src/pages/courses/Pid.tsx
@@ -1,7 +1,7 @@
 /**
  * @file Courses Pid Page
- * 
- * more info on selected courses 
+ *
+ * more info on selected courses
  *
  * @author seedlessapple <luminousseedlessapple@gmail.com>
  *
@@ -28,17 +28,29 @@
  * @version 1.0
  *
  */
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import Divider from "../../components/divider/Divider";
-import NavigationLinks from "../../components/navigationLinks/NavigationLinks";
-import Tab from "../../components/tab/Tab";
-import style from "../../style/pages/courses/course.module.scss";
+import useDatabase from "hooks/useDatabase";
+
+import { useAuth } from "contexts/authContext";
+
+// components
+import Divider from "components/divider/Divider";
+import NavigationLinks from "components/navigationLinks/NavigationLinks";
+import Tab from "components/tab/Tab";
+
+import style from "style/pages/courses/course.module.scss";
+import EditorParser from "editor/EditorParser";
+
+import _ from "lodash";
+
 type Props = {};
 
 const Course = (props: Props) => {
   const { pid } = useParams<"pid">();
   const navigate = useNavigate();
+  const database = useDatabase();
+  const { currentSchool, currentUser, currentSeason } = useAuth();
 
   const [courseData, setCourseData] = useState({
     _id: 123794078125781,
@@ -85,12 +97,85 @@ const Course = (props: Props) => {
     },
   });
 
+  async function getCourseData() {
+    const result = await database.R({
+      location: `syllabuses/${pid}`,
+    });
+    return result;
+  }
+
+  const categories = () => {
+    const res = [];
+    for (let i = 0; i < currentSeason?.subjects.label.length; i++) {
+      res.push(
+        <div className={style.category}>
+          {currentSeason?.subjects.label[i]}: {courseData.subject[i]}
+        </div>
+      );
+    }
+
+    res.push(
+      <div className={style.category}>개설자: {courseData.userName}</div>
+    );
+
+    res.push(
+      <div className={style.category}>
+        멘토:{" "}
+        {_.join(
+          courseData?.teachers.map((teacher) => {
+            return teacher.userName;
+          }),
+          ", "
+        )}
+      </div>
+    );
+
+    res.push(
+      <div className={style.category}>
+        시간:{" "}
+        {_.join(
+          courseData?.time.map((timeBlock) => {
+            return timeBlock.label;
+          }),
+          ", "
+        )}
+      </div>
+    );
+    res.push(<div className={style.category}>학점: {courseData.point}</div>);
+    res.push(
+      <div className={style.category}>
+        강의실: {courseData.classroom || "없음"}
+      </div>
+    );
+    return res;
+  };
+
   useEffect(() => {
     navigate("#강의 계획");
-
+    getCourseData()
+      .then((result) => {
+        setCourseData(result);
+        categories();
+      })
+      .catch((err) => {
+        alert(err.response.data.message);
+        navigate("/courses");
+      });
     return () => {};
   }, []);
+
   const ClassInfo = () => {
+    return (
+      <EditorParser
+        auth="view"
+        // onChange={(data) => {
+        //   setCourseMoreInfo(data);
+        // }}
+        defaultValues={courseData}
+        data={currentSeason?.formSyllabus}
+      />
+    );
+
     return (
       <div className={style.class_info}>
         전반적인 수업 설명 등 사진? 영상? 등
@@ -150,14 +235,7 @@ const Course = (props: Props) => {
       <NavigationLinks />
       <div className={style.title}>{courseData.classTitle}</div>
       <div className={style.categories_container}>
-        <div className={style.categories}>
-          <div className={style.category}>교과: {courseData.subject[0]}</div>
-          <div className={style.category}>과목: {courseData.subject[1]}</div>
-          <div className={style.category}>학점: {courseData.point}</div>
-          <div className={style.category}>난이도: 상</div>
-          <div className={style.category}>학년: 전체</div>
-          <div className={style.category}>강의실: {courseData.classroom}</div>
-        </div>
+        <div className={style.categories}>{categories()}</div>
       </div>
       <Divider />
 


### PR DESCRIPTION
수강신청 메뉴에서 수업 '자세히'를 눌렀을 때 연결되는 페이지 수정

프론트엔드
1. 강의계획서를 Season의 FormSyllabus에 맞춰 보여주는 페이지를 만들었습니다(read-only).

백엔드 (코드상 변경x 데이터베이스 변경o)
1. syllabus 데이터에 필드명에 "."이 들어간 필드가 누락된 것을 확인하고 고쳤습니다.
2. FormSyllabus에서 평가부분이 데이터 연결이 안되어있길래 연결하고 시즌별로 일괄 업데이트했습니다.